### PR TITLE
Fix tournament rewards hook file path

### DIFF
--- a/src/app/(app)/tournaments/[id]/components/tournament-rewards.tsx
+++ b/src/app/(app)/tournaments/[id]/components/tournament-rewards.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/components/ui/table';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Tournament, TournamentReward } from '@/types';
-import { useTournamentRewards } from '../../hooks/use-tournament-rewards';
+import { useTournamentRewards } from '../../../hooks/use-tournament-rewards';
 
 interface TournamentRewardsProps {
   tournament: Tournament;


### PR DESCRIPTION
Corrected the import path for `useTournamentRewards` in `tournament-rewards.tsx` to resolve a module not found error.

The `tournament-rewards.tsx` component, located in `src/app/(app)/tournaments/[id]/components/`, was incorrectly importing `useTournamentRewards` from `../../hooks/use-tournament-rewards`. The `use-tournament-rewards.ts` file is actually located at `src/app/(app)/tournaments/hooks/`, requiring an additional `../` in the relative path.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d23bc25-6914-45ca-b4ba-666d6d093e07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d23bc25-6914-45ca-b4ba-666d6d093e07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

